### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #	docker build -t kbai/ocr-models .
 # Run:
 #	docker run --restart=on-failure --rm -it -p 3002:3002 kbai/ocr-models
-FROM node:argon
+FROM node:hydrogen
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #	docker build -t kbai/ocr-models .
 # Run:
 #	docker run --restart=on-failure --rm -it -p 3002:3002 kbai/ocr-models
-FROM node:hydrogen
+FROM node:22-slim
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ MKDIR = mkdir -p
 ZIP = zip -r
 RM = rm -rf
 
+SED ?= sed
+
 METADATA_SCHEMA = schema/description.schema.json
-MODEL_DESCRIPTIONS = $(shell find . -name 'DESCRIPTION'|sed -e 's,^./,,')
-ZIPPED_MODELS = $(shell find . -name 'DESCRIPTION'|sed -e 's,./models,zip,' -e 's,/DESCRIPTION,.zip,')
+MODEL_DESCRIPTIONS = $(shell find . -name 'DESCRIPTION'|$(SED) -e 's,^./,,')
+ZIPPED_MODELS = $(shell find . -name 'DESCRIPTION'|$(SED) -e 's,./models,zip,' -e 's,/DESCRIPTION,.zip,')
 
 all: zip db
 
@@ -23,14 +25,14 @@ models.ndjson: $(MODEL_DESCRIPTIONS)
 		id=$$desc; \
 		id=$${id/models\//}; \
 		id=$${id/\/DESCRIPTION/}; \
-		id=$${id,,}; \
+		id="$$(echo $$id | tr '[:upper:]' '[:lower:]')"; \
 		zip="zip/$$id.zip"; \
 		zip_size="$$(wc -c zip/$$id.zip|cut -d' ' -f1)"; \
 		echo ">>> DB-ifying $$desc"; \
 		cat "$$desc" \
-			|sed "1a \"_id\": \"$$id\"," \
-			|sed "2a \"zip\": \"$$zip\"," \
-			|sed "3a \"zip-size\": \"$$zip_size\"," \
+			| $(SED) "1a \"_id\": \"$$id\"," \
+			| $(SED) "2a \"zip\": \"$$zip\"," \
+			| $(SED) "3a \"zip-size\": \"$$zip_size\"," \
 			| $(TRAF) -i JSON -o JSON - - \
 			2>/dev/null \
 			>> "$@" ; \

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   },
   "homepage": "https://github.com/kba/ocr-models#readme",
   "dependencies": {
-    "ajv-cli": "^0.9.0",
+    "ajv-cli": "^5.0.0",
     "app-root-path": "^1.3.0",
+    "coffeescript": "1.10.0",
     "express": "^4.14.0",
     "glob": "^7.0.5",
     "nedb": "^1.8.0",
-    "pug": "2.0.0-beta5",
-    "coffee-script": "1.10.0",
-    "traf": "0.0.8"
+    "pug": "^3.0.3",
+    "traf": "^1.1.0"
   },
   "devDependencies": {
     "nodemon": "^1.10.0"


### PR DESCRIPTION
A couple of minor fixes to get the demo page at https://data.bib.uni-mannheim.de/ocr-models working again. @kba is this repo still relevant to anyone? If not, could we stop providing the models at the given web address after the link has been removed from the repo description? 